### PR TITLE
Add ability to set gesturesEnabled within same route.

### DIFF
--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -239,11 +239,6 @@ class CardStack extends React.Component<Props> {
     const { index } = navigation.state;
     const isVertical = mode === 'modal';
 
-    const { options } = this._getScreenDetails(scene);
-
-    const gesturesEnabled =
-      typeof options.gesturesEnabled === 'boolean' && options.gesturesEnabled;
-
     const responder = PanResponder.create({
       onPanResponderTerminate: () => {
         this._isResponding = false;
@@ -259,7 +254,7 @@ class CardStack extends React.Component<Props> {
         event: { nativeEvent: { pageY: number, pageX: number } },
         gesture: any
       ) => {
-        if (index !== scene.index || !gesturesEnabled) {
+        if (index !== scene.index) {
           return false;
         }
         // $FlowFixMe
@@ -363,6 +358,11 @@ class CardStack extends React.Component<Props> {
         });
       },
     });
+
+    const { options } = this._getScreenDetails(scene);
+
+    const gesturesEnabled =
+      typeof options.gesturesEnabled === 'boolean' && options.gesturesEnabled;
 
     const handlers =
       gesturesEnabled && Platform.OS === 'ios' ? responder.panHandlers : {};

--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -364,7 +364,8 @@ class CardStack extends React.Component<Props> {
       },
     });
 
-    const handlers = gesturesEnabled ? responder.panHandlers : {};
+    const handlers =
+      gesturesEnabled && Platform.OS === 'ios' ? responder.panHandlers : {};
     const containerStyle = [
       styles.container,
       this._getTransitionConfig().containerStyle,


### PR DESCRIPTION
Turns out the last implementation with the `globalGesturesEnabled` prop didn't work because react-navigation doesn't recognize changes to the `navigation` state (which is where I had the prop before) unless the route has changed. The CardStack now takes a `getIsBackNavigationEnabled` function, and ensures it returns `true` before allowing the native PanResponder to kick off the swiping animation.